### PR TITLE
Assume the role provided in the config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name="tap-intacct",
       install_requires=[
           'singer-encodings==0.0.2',
           'singer-python==5.1.5',
-          'boto3==1.4.4'
+          'boto3==1.9.57',
+          'backoff==1.3.2',
       ],
       entry_points='''
           [console_scripts]

--- a/tap_intacct/__init__.py
+++ b/tap_intacct/__init__.py
@@ -5,6 +5,7 @@ import singer
 from singer import metadata
 from tap_intacct.discover import discover_streams
 from tap_intacct.sync import sync_stream
+from tap_intacct import s3
 
 LOGGER = singer.get_logger()
 
@@ -50,6 +51,13 @@ def do_sync(config, catalog, state):
 def main():
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
+
+    try:
+        for page in s3.list_files_in_bucket(config['bucket']):
+            break
+        LOGGER.warning("I have direct access to the bucket without assuming the configured role.")
+    except:
+        s3.setup_aws_client(config)
 
     if args.discover:
         do_discover(args.config)

--- a/tap_intacct/s3.py
+++ b/tap_intacct/s3.py
@@ -1,6 +1,16 @@
+import backoff
 import boto3
 import re
 import singer
+
+from botocore.credentials import (
+    AssumeRoleCredentialFetcher,
+    CredentialResolver,
+    DeferredRefreshableCredentials,
+    JSONFileCache
+)
+from botocore.exceptions import ClientError
+from botocore.session import Session
 
 import singer_encodings.csv as csv
 from tap_intacct import conversion
@@ -10,6 +20,58 @@ LOGGER = singer.get_logger()
 SDC_SOURCE_BUCKET_COLUMN = "_sdc_source_bucket"
 SDC_SOURCE_FILE_COLUMN = "_sdc_source_file"
 SDC_SOURCE_LINENO_COLUMN = "_sdc_source_lineno"
+
+def retry_pattern():
+    return backoff.on_exception(backoff.expo,
+                                ClientError,
+                                max_tries=5,
+                                on_backoff=log_backoff_attempt,
+                                factor=10)
+
+
+def log_backoff_attempt(details):
+    LOGGER.info("Error detected communicating with Amazon, triggering backoff: %d try", details.get("tries"))
+
+
+class AssumeRoleProvider():
+    METHOD = 'assume-role'
+
+    def __init__(self, fetcher):
+        self._fetcher = fetcher
+
+    def load(self):
+        return DeferredRefreshableCredentials(
+            self._fetcher.fetch_credentials,
+            self.METHOD
+        )
+
+
+
+@retry_pattern()
+def setup_aws_client(config):
+    role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),
+                                                config['role_name'])
+    session = Session()
+    fetcher = AssumeRoleCredentialFetcher(
+        session.create_client,
+        session.get_credentials(),
+        role_arn,
+        extra_args={
+            'DurationSeconds': 3600,
+            'RoleSessionName': 'TapS3CSV',
+            'ExternalId': config['external_id']
+        },
+        cache=JSONFileCache()
+    )
+
+    refreshable_session = Session()
+    refreshable_session.register_component(
+        'credential_provider',
+        CredentialResolver([AssumeRoleProvider(fetcher)])
+    )
+
+    LOGGER.info("Attempting to assume_role on RoleArn: %s", role_arn)
+    boto3.setup_default_session(botocore_session=refreshable_session)
 
 def get_exported_tables(bucket, company_id, path=None):
     prefix = str.join('/', [path, company_id]) if path else company_id


### PR DESCRIPTION
# Description of change
This PR borrows from `tap-s3-csv` and assumes the role in the config

# Manual QA steps
 - ran the tap
 
# Risks
 - Low, the tap is currently broken
 
# Rollback steps
 - revert this branch
