### PR TITLE
match more input filenames

### DIFF
--- a/tap_intacct/s3.py
+++ b/tap_intacct/s3.py
@@ -172,7 +172,7 @@ def get_input_files_for_table(config, table_name, modified_since=None):
     prefix = str.join('/', [path, company_id]) if path else company_id
     s3_objects = list_files_in_bucket(bucket, prefix)
 
-    pattern = "^" + prefix + '/' + table_name + "\.*\.csv"
+    pattern = "^" + prefix + '/' + table_name + "(?:\..*)?\.csv"
     matcher = re.compile(pattern)
 
     LOGGER.info(


### PR DESCRIPTION
# Description of change
It is rare that we will need to match an input filename in the format `table_name` followed by any number of period (`.`) characters followed by `.csv` as described by the regex submitted in d6b7c18.

The change in d6b7c18 also means that the pattern regex no longer matches the default DDS filename format of `<table_name>.{change|all}.<sequence_number>.<creation_date>.csv` e.g. `TIMESHEET.change.26990.2023-08-02_08.31.43_UTC_del_00001.csv`.

This change properly updates the regex `pattern` to match any file name beginning with the `table_name` and ending in `.csv` which may or may not have additional content in between.

# Manual QA steps
 - Upload sample files to the S3 `bucket`, e.g.
   - `TIMESHEET.change.26990.2023-08-02_08.31.43_UTC_del_00001.csv`
   - `TIMESHEETENTRY.change.26683.2023-07-27_08.26.28_UTC_cr_00000.csv`
   - `Encor Revenues Inception To Date.csv`
 - With a valid `config.json` run `tap-intacct -c config.json --discover`
 - Verify that all uploaded files are Found but that the `TIMESHEETENTRY` file is not processed together with the `TIMESHEET` file.
 
# Risks
 - Not deploying this means that DDS exported files are no longer visible to the tap
 
# Rollback steps
 - revert this branch