### PR TITLE
Implement Refreshable Chained AWS Session for Multi-Account Role Assumption and library updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+ * Update libraries [#13](https://github.com/singer-io/tap-intacct/pull/13)
+
 ## 1.0.3
  * Updated the regex pattern in s3.py to fetch filename_*.csv [#11](https://github.com/singer-io/tap-intacct/pull/11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 1.1.0
- * Update libraries [#13](https://github.com/singer-io/tap-intacct/pull/13)
+ * Adds proxy AWS Account support [#13](https://github.com/singer-io/tap-intacct/pull/13)
+ * Update libraries 
 
 ## 1.0.3
  * Updated the regex pattern in s3.py to fetch filename_*.csv [#11](https://github.com/singer-io/tap-intacct/pull/11)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ The Intacct Tap requires a start_date, a bucket, and an Intacct company ID to fu
   **company_id** - The Company ID used to login to the Intacct UI
   **path** (optional) - An optional path configured in the Intacct UI for use in the S3 bucket
 
+Below are the additional properties, to add in config if running this tap using proxy AWS account as middleware:
+```
+    "proxy_account_id": "221133445566",
+    "proxy_role_name": "proxy_role_with_bucket_access"
+```
+Proxy AWS account will act as a middleware.
+- **proxy_account_id**: This is the Proxy AWS account id.
+- **proxy_role_name**: This is the Proxy IAM role that allows the product AWS account to assume it and then use this role to access S3 bucket in your account.
+
 ### Configure your S3 Bucket
 
 This tap uses the [boto3](https://boto3.readthedocs.io/en/latest/index.html) library for accessing S3. The [credentials](https://boto3.readthedocs.io/en/latest/guide/quickstart.html#configuration)

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,16 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="tap-intacct",
-      version='1.0.3',
+      version='1.1.0',
       description="Singer.io tap for extracting data from Intacct",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
-          'singer-encodings==0.0.2',
-          'singer-python==5.1.5',
-          'boto3==1.9.57',
-          'backoff==1.3.2',
+          'singer-encodings==0.1.3',
+          'singer-python==6.1.1',
+          'boto3==1.39.17',
+          'backoff==2.2.1',
       ],
       entry_points='''
           [console_scripts]

--- a/tap_intacct/__init__.py
+++ b/tap_intacct/__init__.py
@@ -62,7 +62,7 @@ def main():
             # If both are present, call setup_aws_client_with_proxy
             s3.setup_aws_client_with_proxy(config)
         else:
-            # Otherwise, call setup_aws_client        
+            # Otherwise, call setup_aws_client
             s3.setup_aws_client(config)
 
     if args.discover:

--- a/tap_intacct/__init__.py
+++ b/tap_intacct/__init__.py
@@ -57,7 +57,13 @@ def main():
             break
         LOGGER.warning("I have direct access to the bucket without assuming the configured role.")
     except:
-        s3.setup_aws_client(config)
+        # Check if proxy_account_id and proxy_role_name are in config
+        if 'proxy_account_id' in config and 'proxy_role_name' in config:
+            # If both are present, call setup_aws_client_with_proxy
+            s3.setup_aws_client_with_proxy(config)
+        else:
+            # Otherwise, call setup_aws_client        
+            s3.setup_aws_client(config)
 
     if args.discover:
         do_discover(args.config)

--- a/tap_intacct/s3.py
+++ b/tap_intacct/s3.py
@@ -120,15 +120,22 @@ def setup_aws_client_with_proxy(config):
         cache=JSONFileCache(credentials_cache_path)
     )
 
+    # Create RefreshableCredentials for Customer Account
+    refreshable_credentials_cust = RefreshableCredentials.create_from_metadata(
+        metadata=fetcher_cust.fetch_credentials(),
+        refresh_using=fetcher_cust.fetch_credentials,
+        method="sts-assume-role"
+    )
+    session_cust._credentials = refreshable_credentials_cust
+
     # Set up refreshable session for Customer Account
-    refreshable_session_cust = Session()
-    refreshable_session_cust.register_component(
+    session_cust.register_component(
         'credential_provider',
         CredentialResolver([AssumeRoleProvider(fetcher_cust)])
     )
 
     LOGGER.info("Attempting to assume_role on RoleArn: %s", cust_role_arn)
-    boto3.setup_default_session(botocore_session=refreshable_session_cust)
+    boto3.setup_default_session(botocore_session=session_cust)
 
 def get_exported_tables(bucket, company_id, path=None):
     prefix = str.join('/', [path, company_id]) if path else company_id

--- a/tap_intacct/s3.py
+++ b/tap_intacct/s3.py
@@ -1,4 +1,5 @@
 import backoff
+import functools
 import boto3
 import re
 import singer
@@ -22,12 +23,16 @@ SDC_SOURCE_BUCKET_COLUMN = "_sdc_source_bucket"
 SDC_SOURCE_FILE_COLUMN = "_sdc_source_file"
 SDC_SOURCE_LINENO_COLUMN = "_sdc_source_lineno"
 
-def retry_pattern():
-    return backoff.on_exception(backoff.expo,
-                                ClientError,
-                                max_tries=5,
-                                on_backoff=log_backoff_attempt,
-                                factor=10)
+def retry_pattern(fnc):
+    @backoff.on_exception(backoff.expo,
+                          ClientError,
+                          max_tries=5,
+                          on_backoff=log_backoff_attempt,
+                          factor=10)
+    @functools.wraps(fnc)
+    def wrapper(*args, **kwargs):
+        return fnc(*args, **kwargs)
+    return wrapper
 
 
 def log_backoff_attempt(details):

--- a/tap_intacct/s3.py
+++ b/tap_intacct/s3.py
@@ -7,7 +7,8 @@ from botocore.credentials import (
     AssumeRoleCredentialFetcher,
     CredentialResolver,
     DeferredRefreshableCredentials,
-    JSONFileCache
+    JSONFileCache,
+    RefreshableCredentials
 )
 from botocore.exceptions import ClientError
 from botocore.session import Session
@@ -72,6 +73,57 @@ def setup_aws_client(config):
 
     LOGGER.info("Attempting to assume_role on RoleArn: %s", role_arn)
     boto3.setup_default_session(botocore_session=refreshable_session)
+
+@retry_pattern
+def setup_aws_client_with_proxy(config):
+    proxy_role_arn = "arn:aws:iam::{}:role/{}".format(config['proxy_account_id'].replace('-', ''),
+                                                          config['proxy_role_name'])
+    cust_role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''), config['role_name'])
+    credentials_cache_path = config.get("credentials_cache_path", JSONFileCache.CACHE_DIR)
+
+    # Step 1: Assume Role in Account Proxy and set up refreshable session
+    session_proxy = Session()
+    fetcher_proxy = AssumeRoleCredentialFetcher(
+        client_creator=session_proxy.create_client,
+        source_credentials=session_proxy.get_credentials(),
+        role_arn=proxy_role_arn,
+        extra_args={
+            'DurationSeconds': 3600,
+            'RoleSessionName': 'ProxySession'
+        },
+        cache=JSONFileCache(credentials_cache_path)
+    )
+
+    # Refreshable credentials for Account Proxy
+    refreshable_credentials_proxy = RefreshableCredentials.create_from_metadata(
+        metadata=fetcher_proxy.fetch_credentials(),
+        refresh_using=fetcher_proxy.fetch_credentials,
+        method="sts-assume-role"
+    )
+
+    # Step 2: Use Proxy Account's session to assume Role in Customer Account
+    session_cust = Session()
+    fetcher_cust = AssumeRoleCredentialFetcher(
+        client_creator=session_cust.create_client,
+        source_credentials=refreshable_credentials_proxy,
+        role_arn=cust_role_arn,
+        extra_args={
+            'DurationSeconds': 3600,
+            'RoleSessionName': 'TapS3CSVCustSession',
+            'ExternalId': config['external_id']
+        },
+        cache=JSONFileCache(credentials_cache_path)
+    )
+
+    # Set up refreshable session for Customer Account
+    refreshable_session_cust = Session()
+    refreshable_session_cust.register_component(
+        'credential_provider',
+        CredentialResolver([AssumeRoleProvider(fetcher_cust)])
+    )
+
+    LOGGER.info("Attempting to assume_role on RoleArn: %s", cust_role_arn)
+    boto3.setup_default_session(botocore_session=refreshable_session_cust)
 
 def get_exported_tables(bucket, company_id, path=None):
     prefix = str.join('/', [path, company_id]) if path else company_id

--- a/tap_intacct/s3.py
+++ b/tap_intacct/s3.py
@@ -53,7 +53,7 @@ class AssumeRoleProvider():
 
 
 
-@retry_pattern()
+@retry_pattern
 def setup_aws_client(config):
     role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),
                                                 config['role_name'])


### PR DESCRIPTION
# Description of change
- Library updates https://qlik-dev.atlassian.net/browse/SAC-27897
- Functionality to establish a **chained AWS session** for multi-account role assumption, allowing the system to:
1. Assume a role in a `proxy account` and use the resulting credentials.
2. Use the proxy session to assume a secondary role in a `customer account`.
3. Automatically refresh both sessions upon expiration using `RefreshableCredentials` to maintain seamless, uninterrupted access.

### Context

Due to the requirement to perform operations in a `customer account` by first assuming a role in an intermediate (proxy) account, this chained session approach enables:
- **Session Reuse**: Enables reusing a single session across AWS services.
- **Automatic Refreshing**: Ensures that both sessions are refreshed as needed, avoiding disruptions during operations.

### Implementation Details

1. **Primary Role Assumption (Proxy Account)**:
   - Utilizes `AssumeRoleCredentialFetcher` to assume a role in `Proxy`.
   - `RefreshableCredentials` is used to enable automatic refreshing on expiration.
   - This session is cached to avoid redundant calls and improve performance.

2. **Chained Role Assumption (Customer Account)**:
   - Leverages the proxy account session to assume a role in `Customer`.
   - A second `AssumeRoleCredentialFetcher` is set up with `RefreshableCredentials` to automatically refresh upon expiry.

3. **Default Session Setup for boto3**:
   - Configures `boto3` to use this chained session, so all AWS API calls automatically utilize the assumed roles without additional configuration.
   - Logs the current session expiration timestamp to verify that refreshing occurs as expected.
 
# Manual QA steps
 - Tap changes are not tested as we don't have an Intacct account
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
