### PR TITLE
[SAC-28902] - `forced-replication-method` in metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-intacct/bin/activate
             uv pip install pylint
             pylint tap_intacct --disable consider-using-f-string,missing-function-docstring,protected-access,unused-argument,missing-function-docstring,too-many-positional-arguments,wrong-import-order,line-too-long,missing-module-docstring,consider-using-from-import,broad-exception-raised,bare-except,unused-variable,anomalous-backslash-in-string,missing-class-docstring,too-few-public-methods,too-many-locals,unused-import
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-intacct/bin/activate
+            python -m unittest discover tests/unittests -v
 workflows:
   version: 2
   commit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+ * Add forced-replication-method to catalog metadata [#15](https://github.com/singer-io/tap-intacct/pull/15)
+
 ## 1.1.0
  * Adds proxy AWS Account support [#13](https://github.com/singer-io/tap-intacct/pull/13)
  * Update libraries 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="tap-intacct",
-      version='1.1.0',
+      version='1.2.0',
       description="Singer.io tap for extracting data from Intacct",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_intacct/discover.py
+++ b/tap_intacct/discover.py
@@ -20,7 +20,6 @@ def load_metadata(schema):
         if field_name == "RECORDNO":
             mdata = metadata.write(mdata, (), 'table-key-properties', "RECORDNO")
 
-    # Since it reads CSV files from S3 individually hence FULL_TABLE replication
-    mdata = metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
+    mdata = metadata.write(mdata, (), 'forced-replication-method', 'INCREMENTAL')
 
     return metadata.to_list(mdata)

--- a/tap_intacct/discover.py
+++ b/tap_intacct/discover.py
@@ -20,4 +20,7 @@ def load_metadata(schema):
         if field_name == "RECORDNO":
             mdata = metadata.write(mdata, (), 'table-key-properties', "RECORDNO")
 
+    # Since it reads CSV files from S3 individually hence FULL_TABLE replication
+    mdata = metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
+
     return metadata.to_list(mdata)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -8,7 +8,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 # Mock external dependencies before importing
 sys.modules['boto3'] = MagicMock()
-sys.modules['singer'] = MagicMock()
 sys.modules['singer_encodings'] = MagicMock()
 sys.modules['singer_encodings.csv'] = MagicMock()
 sys.modules['backoff'] = MagicMock()
@@ -16,6 +15,46 @@ sys.modules['botocore'] = MagicMock()
 sys.modules['botocore.credentials'] = MagicMock()
 sys.modules['botocore.exceptions'] = MagicMock()
 sys.modules['botocore.session'] = MagicMock()
+
+# Create a proper mock for singer.metadata
+class MockMetadataStore:
+    def __init__(self):
+        self._metadata_store = []
+
+mock_singer = MagicMock()
+mock_metadata = MagicMock()
+
+# Mock the metadata functions to work like the real ones
+def mock_new():
+    return MockMetadataStore()
+
+def mock_write(mdata, breadcrumb, key, value):
+    # Store metadata in a way that can be retrieved
+    mdata._metadata_store.append({
+        'breadcrumb': list(breadcrumb),
+        'metadata': {key: value}
+    })
+    return mdata
+
+def mock_to_list(mdata):
+    if not hasattr(mdata, '_metadata_store'):
+        return []
+    
+    # Group metadata by breadcrumb
+    grouped = {}
+    for item in mdata._metadata_store:
+        breadcrumb_key = tuple(item['breadcrumb'])
+        if breadcrumb_key not in grouped:
+            grouped[breadcrumb_key] = {'breadcrumb': item['breadcrumb'], 'metadata': {}}
+        grouped[breadcrumb_key]['metadata'].update(item['metadata'])
+    
+    return list(grouped.values())
+
+mock_metadata.new = mock_new
+mock_metadata.write = mock_write
+mock_metadata.to_list = mock_to_list
+mock_singer.metadata = mock_metadata
+sys.modules['singer'] = mock_singer
 
 from tap_intacct.discover import load_metadata, discover_streams
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Add the parent directory to the path so we can import tap_intacct
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+# Mock external dependencies before importing
+sys.modules['boto3'] = MagicMock()
+sys.modules['singer'] = MagicMock()
+sys.modules['singer_encodings'] = MagicMock()
+sys.modules['singer_encodings.csv'] = MagicMock()
+sys.modules['backoff'] = MagicMock()
+sys.modules['botocore'] = MagicMock()
+sys.modules['botocore.credentials'] = MagicMock()
+sys.modules['botocore.exceptions'] = MagicMock()
+sys.modules['botocore.session'] = MagicMock()
+
+from tap_intacct.discover import load_metadata, discover_streams
+
+
+class TestDiscoverMetadata(unittest.TestCase):
+    """Test cases for metadata generation in discovery."""
+
+    def test_load_metadata_includes_forced_replication_method(self):
+        """Test that forced-replication-method is included in metadata."""
+        schema = {
+            'properties': {
+                'id': {'type': 'string'},
+                'name': {'type': 'string'}
+            }
+        }
+        
+        metadata_list = load_metadata(schema)
+        
+        # Convert list to dict for easier testing
+        metadata_dict = {}
+        for item in metadata_list:
+            breadcrumb = tuple(item['breadcrumb'])
+            metadata_dict[breadcrumb] = item['metadata']
+        
+        # Check that forced-replication-method is set at table level
+        table_metadata = metadata_dict.get((), {})
+        self.assertEqual(table_metadata.get('forced-replication-method'), 'FULL_TABLE')
+
+    def test_load_metadata_sets_field_inclusion_automatic(self):
+        """Test that all fields have inclusion set to automatic."""
+        schema = {
+            'properties': {
+                'id': {'type': 'string'},
+                'name': {'type': 'string'},
+                'email': {'type': 'string'}
+            }
+        }
+        
+        metadata_list = load_metadata(schema)
+        
+        # Convert list to dict for easier testing
+        metadata_dict = {}
+        for item in metadata_list:
+            breadcrumb = tuple(item['breadcrumb'])
+            metadata_dict[breadcrumb] = item['metadata']
+        
+        # Check that all fields have automatic inclusion
+        for field_name in schema['properties'].keys():
+            field_metadata = metadata_dict.get(('properties', field_name), {})
+            self.assertEqual(field_metadata.get('inclusion'), 'automatic')
+
+    @patch('tap_intacct.s3.get_exported_tables')
+    @patch('tap_intacct.s3.get_sampled_schema_for_table')
+    def test_discover_streams_includes_forced_replication_method(self, mock_get_schema, mock_get_tables):
+        """Test that discover_streams includes forced-replication-method in all streams."""
+        # Mock the S3 functions
+        mock_get_tables.return_value = ['table1', 'table2']
+        mock_get_schema.return_value = {
+            'properties': {
+                'RECORDNO': {'type': 'integer'},
+                'name': {'type': 'string'}
+            }
+        }
+        
+        config = {
+            'bucket': 'test-bucket',
+            'company_id': 'test-company'
+        }
+        
+        streams = discover_streams(config)
+        
+        # Verify we got the expected number of streams
+        self.assertEqual(len(streams), 2)
+        
+        # Check each stream has the forced-replication-method in metadata
+        for stream in streams:
+            metadata_list = stream['metadata']
+            
+            # Find table-level metadata
+            table_metadata = None
+            for item in metadata_list:
+                if item['breadcrumb'] == []:
+                    table_metadata = item['metadata']
+                    break
+            
+            self.assertIsNotNone(table_metadata)
+            self.assertEqual(table_metadata.get('forced-replication-method'), 'FULL_TABLE')

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -81,7 +81,7 @@ class TestDiscoverMetadata(unittest.TestCase):
         
         # Check that forced-replication-method is set at table level
         table_metadata = metadata_dict.get((), {})
-        self.assertEqual(table_metadata.get('forced-replication-method'), 'FULL_TABLE')
+        self.assertEqual(table_metadata.get('forced-replication-method'), 'INCREMENTAL')
 
     def test_load_metadata_sets_field_inclusion_automatic(self):
         """Test that all fields have inclusion set to automatic."""
@@ -141,4 +141,4 @@ class TestDiscoverMetadata(unittest.TestCase):
                     break
             
             self.assertIsNotNone(table_metadata)
-            self.assertEqual(table_metadata.get('forced-replication-method'), 'FULL_TABLE')
+            self.assertEqual(table_metadata.get('forced-replication-method'), 'INCREMENTAL')

--- a/tests/unittests/test_metadata.py
+++ b/tests/unittests/test_metadata.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestMetadataGeneration(unittest.TestCase):
+    """Test cases for metadata generation functionality."""
+
+    def setUp(self):
+        """Set up test fixtures with mocked singer metadata module."""
+        # Mock the singer metadata module
+        self.mock_metadata = MagicMock()
+        self.mock_metadata.new.return_value = {}
+        self.mock_metadata.write.return_value = {}
+        self.mock_metadata.to_list.return_value = []
+        
+        # Create the load_metadata function inline for testing
+        def load_metadata(schema):
+            mdata = self.mock_metadata.new()
+
+            for field_name in schema.get('properties', {}).keys():
+                mdata = self.mock_metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+                if field_name == "RECORDNO":
+                    mdata = self.mock_metadata.write(mdata, (), 'table-key-properties', "RECORDNO")
+
+            # Add forced-replication-method to the metadata
+            mdata = self.mock_metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
+
+            return self.mock_metadata.to_list(mdata)
+        
+        self.load_metadata = load_metadata
+
+    def test_forced_replication_method_is_added(self):
+        """Test that forced-replication-method is added to metadata."""
+        schema = {
+            'properties': {
+                'id': {'type': 'string'},
+                'name': {'type': 'string'}
+            }
+        }
+        
+        result = self.load_metadata(schema)
+        
+        # Verify that forced-replication-method was written to metadata
+        self.mock_metadata.write.assert_any_call(
+            self.mock_metadata.new(),
+            (),  # Empty breadcrumb for table-level metadata
+            'forced-replication-method',
+            'FULL_TABLE'
+        )

--- a/tests/unittests/test_metadata.py
+++ b/tests/unittests/test_metadata.py
@@ -23,7 +23,7 @@ class TestMetadataGeneration(unittest.TestCase):
                     mdata = self.mock_metadata.write(mdata, (), 'table-key-properties', "RECORDNO")
 
             # Add forced-replication-method to the metadata
-            mdata = self.mock_metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
+            mdata = self.mock_metadata.write(mdata, (), 'forced-replication-method', 'INCREMENTAL')
 
             return self.mock_metadata.to_list(mdata)
         
@@ -45,5 +45,5 @@ class TestMetadataGeneration(unittest.TestCase):
             self.mock_metadata.new(),
             (),  # Empty breadcrumb for table-level metadata
             'forced-replication-method',
-            'FULL_TABLE'
+            'INCREMENTAL'
         )


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-28846

> **Adds support for `forced-replication-method` in stream metadata**
> This change introduces the ability to include a `forced_replication_method` field within a stream’s metadata, enabling more fine-grained control over replication behaviour.

 
# Rollback steps
 - revert this branch

