### PR TITLE
Add account_id, external_id, and role_name to REQUIRED_CONFIG_KEYS

### DIFF
--- a/tap_intacct/__init__.py
+++ b/tap_intacct/__init__.py
@@ -9,7 +9,7 @@ from tap_intacct import s3
 
 LOGGER = singer.get_logger()
 
-REQUIRED_CONFIG_KEYS = ["start_date", "bucket", "company_id"]
+REQUIRED_CONFIG_KEYS = ["start_date", "bucket", "company_id", "account_id", "external_id", "role_name"]
 
 def do_discover(config):
     LOGGER.info("Starting discover")


### PR DESCRIPTION
This tap requires account_id, external_id, and role_name in order to connect to AWS, but these keys were not listed as required.

# Description of change

tap_intacct/s3.py, [line 58](https://github.com/singer-io/tap-intacct/blob/master/tap_intacct/s3.py#L58) will throw `KeyError: 'account_id'` if there is no `account_id` in `config`
tap_intacct/s3.py, [line 59](https://github.com/singer-io/tap-intacct/blob/master/tap_intacct/s3.py#L59) will throw `KeyError: 'role_name'` if there is no `role_name` in `config`
tap_intacct/s3.py", [line 68](https://github.com/singer-io/tap-intacct/blob/master/tap_intacct/s3.py#L68) will throw `KeyError: 'external_id'` if there is no `external_id` in `config`

so let's list these as REQUIRED_CONFIG_KEYS.

This may also help address #7 in Stitch.

# Manual QA steps
Run tap-intacct in a new environment without account_id, role_name, or external_id, e.g. with something like

```
{
  "start_date": "2026-01-26T00:00:00Z",
  "bucket": "test-storage-target",
  "company_id": "Test Company"
}
```
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
