### PR TITLE
Bump singer-encodings from 0.1.3 to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 # Changelog
 
 ## 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name="tap-intacct",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
-          'singer-encodings==0.1.3',
+          'singer-encodings==0.5.0',
           'singer-python==6.1.1',
           'boto3==1.39.17',
           'backoff==2.2.1',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="tap-intacct",
-      version='1.2.0',
+      version='1.2.1',
       description="Singer.io tap for extracting data from Intacct",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
@@ -13,7 +13,8 @@ setup(name="tap-intacct",
           'singer-encodings==0.5.0',
           'singer-python==6.1.1',
           'boto3==1.39.17',
-          'backoff==2.2.1',
+          'backoff==2.2.1',,
+        'requests>=2.33.0'
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
Bump to a newer patch version for compatibility.